### PR TITLE
[BC BREAK] `SignedUri` Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ try {
     $signedUri->verify('a secret');
 } catch (VerificationFailed $e) {
     $e::REASON; // ie "Invalid signature."
-    $e->uri(); // SignedUri
+    $e->uri(); // \Zenstruck\Uri
 }
 
 // catch specific exceptions
@@ -295,10 +295,10 @@ try {
     $signedUri->verify('a secret');
 } catch (InvalidSignature $e) {
     $e::REASON; // "Invalid signature."
-    $e->uri(); // SignedUri
+    $e->uri(); // \Zenstruck\Uri
 } catch (ExpiredUri $e) {
     $e::REASON; // "URI has expired."
-    $e->uri(); // SignedUri
+    $e->uri(); // \Zenstruck\Uri
     $e->expiredAt(); // \DateTimeImmutable
 }
 ```
@@ -321,14 +321,14 @@ try {
     $signedUri->verify('a secret', 'some token');
 } catch (InvalidSignature $e) {
     $e::REASON; // "Invalid signature."
-    $e->uri(); // SignedUri
+    $e->uri(); // \Zenstruck\Uri
 } catch (ExpiredUri $e) {
     $e::REASON; // "URI has expired."
-    $e->uri(); // SignedUri
+    $e->uri(); // \Zenstruck\Uri
     $e->expiredAt(); // \DateTimeImmutable
 } catch (UriAlreadyUsed $e) {
     $e::REASON; // "URI has already been used."
-    $e->uri(); // SignedUri
+    $e->uri(); // \Zenstruck\Uri
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Object-oriented wrapper/manipulator for `parse_url` with the following features:
 * Read URI _parts_ as objects (`Scheme`, `Host`, `Path`, `Query`), each with their own
   set of features.
 * Manipulate URI parts or build URI's using a fluent builder API.
+* Sign and verify URI's and make them temporary and/or single-use.
 * Mailto object to help with reading/manipulating `mailto:` URIs.
 * Optional [twig](https://twig.symfony.com/) extension.
 
@@ -225,61 +226,44 @@ These URIs are generated with a token that should change _once the URI has been 
 $uri = Zenstruck\Uri::new('https://example.com/some/path');
 
 (string) $uri->sign('a secret')->singleUse('some-token'); // "https://example.com/some/path?_token=...&_hash=..."
-
-// create a single-use, temporary uri
-(string) $uri->sign('a secret')
-    ->singleUse('some-token')
-    ->expires('+30 minutes')
-; // "https://example.com/some/path?_expires=...&_token=...&_hash=..."
 ```
 
 > **Note**: The URL is first hashed with this token, then hashed again with secret to ensure it hasn't
 > been tampered with.
 
-### `SignedUri`
+### Signed URI Builder
 
-Calling `Zenstruck\Uri::sign()` returns a `Zenstruck\Uri\Signed\Builder` object. Calling `Builder::create()`
-returns a `Zenstruck\Uri\SignedUri` object that extends `Zenstruck\Uri` and has some helpful methods.
-
-> **Note**: `Zenstruck\Uri\Signed\Builder` is immutable objects so any manipulations results in a new instance.
-
-> **Note**: `Zenstruck\Uri\SignedUri` cannot be cloned so the [manipulation methods](#manipulating-uris) cannot be called.
+Calling `Zenstruck\Uri::sign()` returns a `Zenstruck\Uri\Signed\Builder` object that can be used to
+create single-use _and_ temporary URIs.
 
 ```php
 $uri = Zenstruck\Uri::new('https://example.com/some/path');
 
 $builder = $uri->sign('a secret'); // Zenstruck\Uri\Signed\Builder
 
-$signedUri = $builder
-    ->singleUse('a token')
-    ->expires('tomorrow')
-    ->create()
-; // Zenstruck\Uri\SignedUri
+// create a single-use, temporary uri
+$builder = $uri->sign('a secret')
+    ->singleUse('some-token')
+    ->expires('+30 minutes')
+;
 
-$signedUri->isSingleUse(); // true
-$signedUri->isTemporary(); // true
-$signedUri->expiresAt(); // \DateTimeImmutable
-
-// extends Zenstruck\Uri
-$signedUri->query(); // Zenstruck\Uri\Query
+(string) $builder; // "https://example.com/some/path?_expires=...&_token=...&_hash=..."
 ```
+
+> **Note**: `Zenstruck\Uri\Signed\Builder` is immutable objects so any manipulations results in a new instance.
 
 ### Verification
 
-To verify a signed URI, create an instance of `Zenstruck\Uri\SignedUri` and call `SignedUri::isVerified()` to
-get true/false or `SignedUri::verify()` to throw specific exceptions:
+To verify a signed URI, create an instance of `Zenstruck\Uri` and call `Uri::isVerified()` to
+get true/false or `Uri::verify()` to throw specific exceptions:
 
 ```php
-use Zenstruck\Uri\SignedUri;
+use Zenstruck\Uri;
 use Zenstruck\Uri\Signed\Exception\InvalidSignature;
 use Zenstruck\Uri\Signed\Exception\ExpiredUri;
 use Zenstruck\Uri\Signed\Exception\VerificationFailed;
 
-$signedUri = SignedUri::new('http://example.com/some/path?_hash=...');
-
-// can also create from an instance of Symfony\Component\HttpFoundation\Request
-/** @var Symfony\Component\HttpFoundation\Request $request */
-$signedUri = SignedUri::new($request);
+$signedUri = Uri::new('http://example.com/some/path?_hash=...');
 
 $signedUri->isVerified('a secret'); // true/false
 
@@ -312,7 +296,7 @@ use Zenstruck\Uri\Signed\Exception\InvalidSignature;
 use Zenstruck\Uri\Signed\Exception\ExpiredUri;
 use Zenstruck\Uri\Signed\Exception\UriAlreadyUsed;
 
-/** @var \Zenstruck\Uri\SignedUri $uri */
+/** @var \Zenstruck\Uri $uri */
 
 $uri->isVerified('a secret', 'some token'); // true/false
 
@@ -330,6 +314,37 @@ try {
     $e::REASON; // "URI has already been used."
     $e->uri(); // \Zenstruck\Uri
 }
+```
+
+### `SignedUri`
+
+`Zenstruck\Uri\Signed\Builder::create()` and `Zenstruck\Uri::verify()` both return a `Zenstruck\Uri\SignedUri`
+object that extends `Zenstruck\Uri` and has some helpful methods.
+
+> **Note**: `Zenstruck\Uri\SignedUri` is:
+> 1. Always considered verified.
+> 2. Cannot be cloned so the [manipulation methods](#manipulating-uris) cannot be called.
+> 3. Cannot be constructed directly, must be created through `Uri::verify()` or `Builder::create()`
+
+```php
+$uri = Zenstruck\Uri::new('https://example.com/some/path');
+
+// create from the builder
+$signedUri = $uri->sign('a secret')
+    ->singleUse('a token')
+    ->expires('tomorrow')
+    ->create()
+; // Zenstruck\Uri\SignedUri
+
+// create from verify
+$uri->verify('a secret'); // Zenstruck\Uri\SignedUri
+
+$signedUri->isSingleUse(); // true
+$signedUri->isTemporary(); // true
+$signedUri->expiresAt(); // \DateTimeImmutable
+
+// extends Zenstruck\Uri
+$signedUri->query(); // Zenstruck\Uri\Query
 ```
 
 ## `Mailto` URIs

--- a/src/Uri/Signed/Exception/ExpiredUri.php
+++ b/src/Uri/Signed/Exception/ExpiredUri.php
@@ -2,6 +2,8 @@
 
 namespace Zenstruck\Uri\Signed\Exception;
 
+use Zenstruck\Uri;
+
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
@@ -9,12 +11,20 @@ final class ExpiredUri extends VerificationFailed
 {
     public const REASON = 'URI has expired.';
 
+    private \DateTimeImmutable $expiredAt;
+
+    /**
+     * @internal
+     */
+    public function __construct(Uri $uri, \DateTimeImmutable $expiredAt, ?string $message = null, ?\Throwable $previous = null)
+    {
+        parent::__construct($uri, $message, $previous);
+
+        $this->expiredAt = $expiredAt;
+    }
+
     public function expiredAt(): \DateTimeImmutable
     {
-        $expiredAt = $this->uri()->expiresAt();
-
-        \assert($expiredAt instanceof \DateTimeImmutable);
-
-        return $expiredAt;
+        return $this->expiredAt;
     }
 }

--- a/src/Uri/Signed/Exception/VerificationFailed.php
+++ b/src/Uri/Signed/Exception/VerificationFailed.php
@@ -2,7 +2,7 @@
 
 namespace Zenstruck\Uri\Signed\Exception;
 
-use Zenstruck\Uri\SignedUri;
+use Zenstruck\Uri;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -11,16 +11,19 @@ abstract class VerificationFailed extends \RuntimeException
 {
     public const REASON = '';
 
-    private SignedUri $uri;
+    private Uri $uri;
 
-    final public function __construct(SignedUri $uri, ?string $message = null, ?\Throwable $previous = null)
+    /**
+     * @internal
+     */
+    public function __construct(Uri $uri, ?string $message = null, ?\Throwable $previous = null)
     {
         $this->uri = $uri;
 
         parent::__construct($message ?? static::REASON, 0, $previous);
     }
 
-    final public function uri(): SignedUri
+    final public function uri(): Uri
     {
         return $this->uri;
     }

--- a/src/Uri/SignedUri.php
+++ b/src/Uri/SignedUri.php
@@ -8,99 +8,64 @@ use Zenstruck\Uri\Signed\Builder;
 use Zenstruck\Uri\Signed\Exception\ExpiredUri;
 use Zenstruck\Uri\Signed\Exception\InvalidSignature;
 use Zenstruck\Uri\Signed\Exception\UriAlreadyUsed;
-use Zenstruck\Uri\Signed\Exception\VerificationFailed;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
 final class SignedUri extends Uri
 {
-    public const EXPIRES_AT_KEY = '_expires';
-    public const SINGLE_USE_TOKEN_KEY = '_token';
+    private const EXPIRES_AT_KEY = '_expires';
+    private const SINGLE_USE_TOKEN_KEY = '_token';
+
+    private ?\DateTimeImmutable $expiresAt;
+
+    /**
+     * @param string|Uri $uri
+     */
+    private function __construct($uri, ?\DateTimeImmutable $expiresAt)
+    {
+        $this->expiresAt = $expiresAt;
+
+        parent::__construct($uri);
+    }
 
     public function __clone()
     {
-        throw new \LogicException(\sprintf('%s (%s) cannot be cloned.', static::class, $this));
+        throw new \LogicException(\sprintf('%s (%s) cannot be cloned.', self::class, $this));
     }
 
     /**
-     * @param string|UriSigner $secret
-     * @param string|null      $singleUseToken If passed, this value MUST change once the URL is considered "used"
+     * @internal
      *
-     * @throws ExpiredUri       if the URI has expired
-     * @throws UriAlreadyUsed   if the URI has already been used
-     * @throws InvalidSignature if the URI could not be verified
+     * @param Builder $builder
      */
-    public function verify($secret, ?string $singleUseToken = null): void
+    public static function new($builder = null): self
     {
-        if (!\class_exists(UriSigner::class)) {
-            throw new \LogicException('symfony/http-kernel is required to verify signed URIs. composer require symfony/http-kernel.');
+        if (!$builder instanceof Builder) {
+            throw new \LogicException(\sprintf('"%s" is internal and cannot be called directly.', __METHOD__));
         }
 
-        $signer = $secret instanceof UriSigner ? $secret : new UriSigner($secret);
+        [$uri, $signer, $expiresAt, $singleUseToken] = $builder->context();
 
-        if (!$signer->check($this)) {
-            throw new InvalidSignature($this);
+        if ($expiresAt) {
+            $uri = $uri->withQueryParam(self::EXPIRES_AT_KEY, $expiresAt->getTimestamp());
         }
 
-        $expiresAt = $this->expiresAt();
-
-        if ($expiresAt && $expiresAt < new \DateTimeImmutable('now')) {
-            throw new ExpiredUri($this, $expiresAt);
+        if ($singleUseToken) {
+            $uri = (new UriSigner($singleUseToken, self::SINGLE_USE_TOKEN_KEY))->sign($uri);
         }
 
-        $singleUseSignature = $this->query()->get(self::SINGLE_USE_TOKEN_KEY);
-
-        if (!$singleUseSignature && !$singleUseToken) {
-            return;
-        }
-
-        if ($singleUseSignature && !$singleUseToken) {
-            throw new InvalidSignature($this, 'URI is single use but this was not expected.');
-        }
-
-        if (!$singleUseSignature && $singleUseToken) { // @phpstan-ignore-line
-            throw new InvalidSignature($this, 'Expected single use URI.');
-        }
-
-        // hack to get the correct parameter used
-        $parameter = \Closure::bind(fn(UriSigner $signer) => $signer->parameter, null, $signer);
-
-        // remove the _hash query parameter
-        $uri = (new Uri($this))->withoutQueryParams($parameter($signer));
-
-        if (!(new UriSigner($singleUseToken, self::SINGLE_USE_TOKEN_KEY))->check($uri)) { // @phpstan-ignore-line
-            throw new UriAlreadyUsed($this);
-        }
-    }
-
-    /**
-     * @param string|UriSigner $secret
-     * @param string|null      $singleUseToken If passed, this value MUST change once the URL is considered "used"
-     */
-    public function isVerified($secret, ?string $singleUseToken = null): bool
-    {
-        try {
-            $this->verify($secret, $singleUseToken);
-
-            return true;
-        } catch (VerificationFailed $e) {
-            return false;
-        }
+        return new self($signer->sign($uri), $expiresAt);
     }
 
     public function expiresAt(): ?\DateTimeImmutable
     {
-        if ($timestamp = $this->query()->getInt(self::EXPIRES_AT_KEY)) {
-            return \DateTimeImmutable::createFromFormat('U', (string) $timestamp) ?: null;
-        }
-
-        return null;
+        return $this->expiresAt;
     }
 
     public function isTemporary(): bool
     {
-        return $this->query()->has(self::EXPIRES_AT_KEY);
+        return $this->expiresAt instanceof \DateTimeImmutable;
     }
 
     public function isSingleUse(): bool
@@ -108,8 +73,64 @@ final class SignedUri extends Uri
         return $this->query()->has(self::SINGLE_USE_TOKEN_KEY);
     }
 
-    public function sign($secret): Builder
+    /**
+     * @param string|UriSigner $secret
+     */
+    protected static function createVerified(Uri $uri, $secret, ?string $singleUseToken): self
     {
-        throw new \BadMethodCallException(\sprintf('%s (%s) is already signed.', static::class, $this));
+        if (!\class_exists(UriSigner::class)) {
+            throw new \LogicException('symfony/http-kernel is required to verify signed URIs. composer require symfony/http-kernel.');
+        }
+
+        if ($uri instanceof self) {
+            throw new \LogicException(\sprintf('"%s" is already signed.', $uri));
+        }
+
+        $signer = $secret instanceof UriSigner ? $secret : new UriSigner($secret);
+
+        if (!$signer->check($uri)) {
+            throw new InvalidSignature($uri);
+        }
+
+        $expiresAt = self::calculateExpiresAt($uri);
+
+        if ($expiresAt && $expiresAt < new \DateTimeImmutable('now')) {
+            throw new ExpiredUri($uri, $expiresAt);
+        }
+
+        $singleUseSignature = $uri->query()->get(self::SINGLE_USE_TOKEN_KEY);
+
+        if (!$singleUseSignature && !$singleUseToken) {
+            return new self($uri, $expiresAt);
+        }
+
+        if ($singleUseSignature && !$singleUseToken) {
+            throw new InvalidSignature($uri, 'URI is single use but this was not expected.');
+        }
+
+        if (!$singleUseSignature && $singleUseToken) { // @phpstan-ignore-line
+            throw new InvalidSignature($uri, 'Expected single use URI.');
+        }
+
+        // hack to get the correct parameter used
+        $parameter = \Closure::bind(fn(UriSigner $signer) => $signer->parameter, null, $signer);
+
+        // remove the _hash query parameter
+        $withoutHash = $uri->withoutQueryParams($parameter($signer));
+
+        if (!(new UriSigner($singleUseToken, self::SINGLE_USE_TOKEN_KEY))->check($withoutHash)) { // @phpstan-ignore-line
+            throw new UriAlreadyUsed($uri);
+        }
+
+        return new self($uri, $expiresAt);
+    }
+
+    private static function calculateExpiresAt(Uri $uri): ?\DateTimeImmutable
+    {
+        if ($timestamp = $uri->query()->getInt(self::EXPIRES_AT_KEY)) {
+            return \DateTimeImmutable::createFromFormat('U', (string) $timestamp) ?: null;
+        }
+
+        return null;
     }
 }

--- a/src/Uri/SignedUri.php
+++ b/src/Uri/SignedUri.php
@@ -46,7 +46,7 @@ final class SignedUri extends Uri
         $expiresAt = $this->expiresAt();
 
         if ($expiresAt && $expiresAt < new \DateTimeImmutable('now')) {
-            throw new ExpiredUri($this);
+            throw new ExpiredUri($this, $expiresAt);
         }
 
         $singleUseSignature = $this->query()->get(self::SINGLE_USE_TOKEN_KEY);


### PR DESCRIPTION
Prevents `SignedUri`'s from being created in an _unverified state_.

Closes #8.
Closes #7.